### PR TITLE
DP-1239 - Add version input to docker image actions

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -25,6 +25,7 @@ jobs:
       public: true
       public_image: ce/ros-master-noetic
       deploy: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v')}}
+      version: ${GITHUB_REF##*/}
       push_latest: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v') }}
       snyk_check: true
       platforms: linux/amd64, linux/arm/v7, linux/arm64


### PR DESCRIPTION
Add 'version' input to docker image action.

Pipeline Run: https://github.com/MOV-AI/containers-ros-master/actions/runs/5764687333

Version Tag generated: merge (corresponding to the tag associated with the workflow, just as was done previously)
Push Flag: false

-------------------------

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
